### PR TITLE
Version Bump Due To Failed PyPi Release

### DIFF
--- a/lunchable/_version.py
+++ b/lunchable/_version.py
@@ -3,4 +3,4 @@ Lunchable Version File
 """
 
 __lunchable__ = "lunchable"
-__version__ = "0.1."
+__version__ = "0.1.8"

--- a/lunchable/_version.py
+++ b/lunchable/_version.py
@@ -3,4 +3,4 @@ Lunchable Version File
 """
 
 __lunchable__ = "lunchable"
-__version__ = "0.1.7"
+__version__ = "0.1."


### PR DESCRIPTION
This Pull Request Re-Releases Lunchable Due to a [Failed PyPi Release](https://github.com/juftin/lunchable/runs/4723055840?check_suite_focus=true). 