### PR TITLE
Add optional financial partner group, fix bug with partner ID matching

### DIFF
--- a/lunchable/_cli.py
+++ b/lunchable/_cli.py
@@ -200,12 +200,19 @@ tag_transactions = click.option(
 financial_partner_id = click.option(
     "--financial-partner-id",
     default=None,
+    type=click.INT,
     help="Splitwise ID of your financial partner.",
 )
 financial_partner_email = click.option(
     "--financial-partner-email",
     default=None,
     help="Splitwise Email Address of your financial partner.",
+)
+financial_partner_group_id = click.option(
+    "--financial-partner-group-id",
+    default=None,
+    type=click.INT,
+    help="Splitwise Group ID for financial partner transactions.",
 )
 
 
@@ -228,6 +235,7 @@ def make_splitlunch(**kwargs):
 @tag_transactions
 @financial_partner_id
 @financial_partner_email
+@financial_partner_group_id
 def make_splitlunch_import(**kwargs):
     """
     Import `SplitLunchImport` tagged transactions to Splitwise and Split them in Lunch Money
@@ -240,9 +248,11 @@ def make_splitlunch_import(**kwargs):
 
     financial_partner_id = kwargs.pop("financial_partner_id")
     financial_partner_email = kwargs.pop("financial_partner_email")
+    financial_partner_group_id = kwargs.pop("financial_partner_group_id")
     splitlunch = SplitLunch(
         financial_partner_id=financial_partner_id,
         financial_partner_email=financial_partner_email,
+        financial_partner_group_id=financial_partner_group_id,
     )
     results = splitlunch.make_splitlunch_import(**kwargs)
     print_json(data=results, default=pydantic_encoder)
@@ -252,6 +262,7 @@ def make_splitlunch_import(**kwargs):
 @tag_transactions
 @financial_partner_id
 @financial_partner_email
+@financial_partner_group_id
 def make_splitlunch_direct_import(**kwargs):
     """
     Import `SplitLunchDirectImport` tagged transactions to Splitwise and Split them in Lunch Money
@@ -264,9 +275,11 @@ def make_splitlunch_direct_import(**kwargs):
 
     financial_partner_id = kwargs.pop("financial_partner_id")
     financial_partner_email = kwargs.pop("financial_partner_email")
+    financial_partner_group_id = kwargs.pop("financial_partner_group_id")
     splitlunch = SplitLunch(
         financial_partner_id=financial_partner_id,
         financial_partner_email=financial_partner_email,
+        financial_partner_group_id=financial_partner_group_id,
     )
     results = splitlunch.make_splitlunch_direct_import(**kwargs)
     print_json(data=results, default=pydantic_encoder)

--- a/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
+++ b/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
@@ -97,6 +97,8 @@ class SplitLunch(splitwise.Splitwise):
         Splitwise User ID of financial partner
     financial_partner_email: Optional[str]
         Splitwise linked email address of financial partner
+    financial_partner_group_id: Optional[int]
+        Splitwise Group ID for financial partner transactions
     consumer_key: Optional[str]
         Consumer Key provided by Splitwise. Defaults to `SPLITWISE_CONSUMER_KEY` environment
         variable
@@ -116,6 +118,7 @@ class SplitLunch(splitwise.Splitwise):
         lunch_money_access_token: Optional[str] = None,
         financial_partner_id: Optional[int] = None,
         financial_partner_email: Optional[str] = None,
+        financial_partner_group_id: Optional[int] = None,
         consumer_key: Optional[str] = None,
         consumer_secret: Optional[str] = None,
         api_key: Optional[str] = None,
@@ -130,6 +133,8 @@ class SplitLunch(splitwise.Splitwise):
             Splitwise User ID of financial partner
         financial_partner_email: Optional[str]
             Splitwise linked email address of financial partner
+        financial_partner_group_id: Optional[int]
+            Splitwise Group ID for financial partner transactions
         consumer_key: Optional[str]
             Consumer Key provided by Splitwise. Defaults to `SPLITWISE_CONSUMER_KEY` environment
             variable
@@ -154,6 +159,7 @@ class SplitLunch(splitwise.Splitwise):
         self.financial_partner: splitwise.Friend = self.get_friend(
             friend_id=financial_partner_id, email_address=financial_partner_email
         )
+        self.financial_group = financial_partner_group_id
         self.last_check: Optional[datetime.datetime] = None
         self.lunchable = (
             LunchMoney(access_token=lunch_money_access_token)
@@ -255,6 +261,8 @@ class SplitLunch(splitwise.Splitwise):
         # CREATE THE NEW EXPENSE OBJECT
         new_expense = splitwise.Expense()
         new_expense.setDescription(desc=description)
+        if self.financial_group:
+            new_expense.setGroupId(self.financial_group)
         # GET AND SET AMOUNTS OWED
         primary_user_owes, financial_partner_owes = self.split_a_transaction(
             amount=amount
@@ -308,6 +316,8 @@ class SplitLunch(splitwise.Splitwise):
         # CREATE THE NEW EXPENSE OBJECT
         new_expense = splitwise.Expense()
         new_expense.setDescription(desc=description)
+        if self.financial_group:
+            new_expense.setGroupId(self.financial_group)
         # GET AND SET AMOUNTS OWED
         new_expense.setCost(cost=amount)
         # CONFIGURE PRIMARY USER


### PR DESCRIPTION
# Description

- Add optional `--financial-partner-group-id` for categorizing Splitwise transactions into groups. Ex: `https://secure.splitwise.com/#/groups/12345678`
- Make `--financial-partner-id` an `int`. Was `str` previously, thus matching on financial partner ID would always fail with an `SplitLunchError` exception (as Splitwise user ID is an `int`)

# Has This Been Tested?

- Tested locally, works as expected. Expenses created and assigned to my financial partner, using their splitwise user ID and categorized into the Splitwise group that I specified:
```
$ docker-compose run lunchable lunchable plugins splitlunch splitlunch-import --tag-transactions --financial-partner-id 123456 --financial-partner-group-id 12345678
[
  {
    "original_id": XXXXXXX,
    "payee": "Expense Payee",
    "amount": 123.45,
    "reimbursement_amount": 61.73,
    "notes": null,
    "splitwise_id": XXXXXXX,
    "updated": true,
    "split": [
      XXXXXX,
      XXXXXX
    ]
  }
]
```

# Checklist:

- [X] I've read the contributing guidelines of this project
- [ ] I've added a `BUMP_MAJOR`, `BUMP_MINOR`, or `BUMP_PATCH` label to this PR to increment the version
- [X] I've installed and used `.pre_commit` on all my code
- [X] I have documented my code, particularly in hard-to-understand areas
- [X] I have made any necessary corresponding changes to the documentation