### PR TITLE
Add --dated-{before,after} options to splitlunch refresh

### DIFF
--- a/lunchable/_cli.py
+++ b/lunchable/_cli.py
@@ -2,6 +2,7 @@
 Lunchmoney CLI
 """
 
+import datetime
 import logging
 from json import JSONDecodeError
 from typing import Any, Dict, Optional, Union
@@ -152,6 +153,18 @@ def splitlunch() -> None:
     pass
 
 
+dated_after = click.option(
+    "--dated-after",
+    default=None,
+    help="ISO 8601 Date time. Return expenses later that this date",
+)
+dated_before = click.option(
+    "--dated-before",
+    default=None,
+    help="ISO 8601 Date time. Return expenses earlier than this date",
+)
+
+
 @splitlunch.command("expenses")
 @click.option(
     "--limit", default=None, help="Limit the amount of Results. 0 returns everything."
@@ -160,16 +173,8 @@ def splitlunch() -> None:
 @click.option("--limit", default=None, help="Number of expenses to be returned")
 @click.option("--group-id", default=None, help="GroupID of the expenses")
 @click.option("--friendship-id", default=None, help="FriendshipID of the expenses")
-@click.option(
-    "--dated-after",
-    default=None,
-    help="ISO 8601 Date time. Return expenses later that this date",
-)
-@click.option(
-    "--dated-before",
-    default=None,
-    help="ISO 8601 Date time. Return expenses earlier than this date",
-)
+@dated_after
+@dated_before
 @click.option(
     "--updated-after",
     default=None,
@@ -311,6 +316,8 @@ def update_splitwise_balance() -> None:
 
 
 @splitlunch.command("refresh")
+@dated_after
+@dated_before
 @click.option(
     "--allow-self-paid/--no-allow-self-paid",
     default=False,
@@ -321,7 +328,12 @@ def update_splitwise_balance() -> None:
     default=False,
     help="Allow payments to be imported (filtered out by default).",
 )
-def refresh_splitwise_transactions(allow_self_paid: bool, allow_payments: bool) -> None:
+def refresh_splitwise_transactions(
+    dated_before: Optional[datetime.datetime],
+    dated_after: Optional[datetime.datetime],
+    allow_self_paid: bool,
+    allow_payments: bool,
+) -> None:
     """
     Import New Splitwise Transactions to Lunch Money and
 
@@ -333,7 +345,10 @@ def refresh_splitwise_transactions(allow_self_paid: bool, allow_payments: bool) 
 
     splitlunch = SplitLunch()
     response = splitlunch.refresh_splitwise_transactions(
-        allow_self_paid=allow_self_paid, allow_payments=allow_payments
+        dated_before=dated_before,
+        dated_after=dated_after,
+        allow_self_paid=allow_self_paid,
+        allow_payments=allow_payments,
     )
     print_json(data=response, default=pydantic_encoder)
 

--- a/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
+++ b/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
@@ -1121,6 +1121,8 @@ class SplitLunch(splitwise.Splitwise):
 
     def get_new_transactions(
         self,
+        dated_after: Optional[datetime.datetime] = None,
+        dated_before: Optional[datetime.datetime] = None,
     ) -> Tuple[List[SplitLunchExpense], List[TransactionObject]]:
         """
         Get Splitwise Transactions that don't exist in Lunch Money
@@ -1145,7 +1147,11 @@ class SplitLunch(splitwise.Splitwise):
             for item in splitlunch_expenses
             if item.external_id is not None
         }
-        splitwise_expenses = self.get_expenses(limit=0)
+        splitwise_expenses = self.get_expenses(
+            limit=0,
+            dated_after=dated_after,
+            dated_before=dated_before,
+        )
         splitwise_ids = {item.splitwise_id for item in splitwise_expenses}
         new_ids = splitwise_ids.difference(splitlunch_ids)
         new_expenses = [
@@ -1199,6 +1205,8 @@ class SplitLunch(splitwise.Splitwise):
 
     def refresh_splitwise_transactions(
         self,
+        dated_after: Optional[datetime.datetime] = None,
+        dated_before: Optional[datetime.datetime] = None,
         allow_self_paid: bool = False,
         allow_payments: bool = False,
     ) -> Dict[str, Any]:
@@ -1212,7 +1220,10 @@ class SplitLunch(splitwise.Splitwise):
         -------
         List[SplitLunchExpense]
         """
-        new_transactions, deleted_transactions = self.get_new_transactions()
+        new_transactions, deleted_transactions = self.get_new_transactions(
+            dated_after=dated_after,
+            dated_before=dated_before,
+        )
         self.splitwise_to_lunchmoney(
             expenses=new_transactions,
             allow_self_paid=allow_self_paid,


### PR DESCRIPTION
# Description

This introduces two new options to `lunchable plugins splitlunch refresh`. Both `--dated-after` and `--dated-before` behave as they do in the `lunchable plugins splitlunch expenses` subcommand. Notably, they do only affect the transactions fetched from Splitwise; the tool continues to fetch all transactions from Lunch Money for comparison.

I've been using Jan 1, 2023 as the starting epoch for my Lunch Money history, and would like to avoid importing older transactions into my account.

(As a note, I promised some additional options beyond these, but I'm still working on getting them to behave correctly, whereas this was fairly straightforward, so I figured I'd go ahead and push it up first)

# Has This Been Tested?

I've been testing this against my own account by running `poetry run lunchable plugins splitlunch refresh --dated-after 2022-12-31`.

# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/lunchable/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
