### PR TITLE
Add --allow-self-paid and --allow-payments flags to splitlunch refresh

### DIFF
--- a/docs/source/splitlunch.rst
+++ b/docs/source/splitlunch.rst
@@ -24,9 +24,11 @@ have prerequisites:
 
 Auto Importer
 -------------
-It supports the auto-importing of Splitwise expenses into Lunch Money
-transactions. This requires a manual asset exist in your Lunch Money
-account with "Splitwise" in the Name.
+It supports the auto-importing of Splitwise expenses into Lunch Money transactions. This requires a
+manual asset exist in your Lunch Money account with "Splitwise" in the Name. Expenses that have been
+deleted or which don't impact you (i.e. are only between other users in your group) are skipped. By
+default, payments and expenses for which you are recorded as the payer are skipped as well, but
+these can be overridden by the `--allow-payments` and `--allow-self-paid` CLI flags, respectively.
 
     Prerequisites:
        - Accounts:

--- a/lunchable/_cli.py
+++ b/lunchable/_cli.py
@@ -311,7 +311,17 @@ def update_splitwise_balance() -> None:
 
 
 @splitlunch.command("refresh")
-def refresh_splitwise_transactions() -> None:
+@click.option(
+    "--allow-self-paid/--no-allow-self-paid",
+    default=False,
+    help="Allow self-paid expenses to be imported (filtered out by default).",
+)
+@click.option(
+    "--allow-payments/--no-allow-payments",
+    default=False,
+    help="Allow payments to be imported (filtered out by default).",
+)
+def refresh_splitwise_transactions(**kwargs: str) -> None:
     """
     Import New Splitwise Transactions to Lunch Money and
 
@@ -322,7 +332,7 @@ def refresh_splitwise_transactions() -> None:
     from lunchable.plugins.splitlunch import SplitLunch
 
     splitlunch = SplitLunch()
-    response = splitlunch.refresh_splitwise_transactions()
+    response = splitlunch.refresh_splitwise_transactions(**kwargs)
     print_json(data=response, default=pydantic_encoder)
 
 

--- a/lunchable/_cli.py
+++ b/lunchable/_cli.py
@@ -321,7 +321,7 @@ def update_splitwise_balance() -> None:
     default=False,
     help="Allow payments to be imported (filtered out by default).",
 )
-def refresh_splitwise_transactions(**kwargs: str) -> None:
+def refresh_splitwise_transactions(allow_self_paid: bool, allow_payments: bool) -> None:
     """
     Import New Splitwise Transactions to Lunch Money and
 
@@ -332,7 +332,9 @@ def refresh_splitwise_transactions(**kwargs: str) -> None:
     from lunchable.plugins.splitlunch import SplitLunch
 
     splitlunch = SplitLunch()
-    response = splitlunch.refresh_splitwise_transactions(**kwargs)
+    response = splitlunch.refresh_splitwise_transactions(
+        allow_self_paid=allow_self_paid, allow_payments=allow_payments
+    )
     print_json(data=response, default=pydantic_encoder)
 
 

--- a/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
+++ b/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
@@ -39,11 +39,11 @@ except ImportError as ie:
     raise LunchMoneyImportError(_pip_extra_error)
 
 
-def _get_expense_impact(
+def _get_splitwise_impact(
     expense: splitwise.Expense, current_user_id: int
 ) -> Tuple[float, bool]:
     """
-    Get the Financial Impact of a Splitwise Expense
+    Get the Financial Impact of a Splitwise Transaction
 
     Parameters
     ----------
@@ -66,60 +66,6 @@ def _get_expense_impact(
         assert len(expense.users) == 1
         if expense.users[0].id == current_user_id:
             self_paid = True
-    return financial_impact, self_paid
-
-
-def _get_payment_impact(
-    expense: splitwise.Expense, current_user_id: int
-) -> Tuple[float, bool]:
-    """
-    Get the Financial Impact of a Splitwise Payment
-
-    Parameters
-    ----------
-    expense: splitwise.Expense
-
-    Returns
-    -------
-    Tuple[float, bool]
-    """
-    financial_impact = 0.00
-    self_paid = False
-    if len(expense.repayments) >= 1:
-        for debt in expense.repayments:
-            if debt.fromUser == current_user_id:
-                financial_impact += float(debt.amount)
-            elif debt.toUser == current_user_id:
-                self_paid = True
-                financial_impact -= float(debt.amount)
-    elif len(expense.repayments) == 0:
-        if expense.users[0].id == current_user_id:
-            financial_impact -= float(expense.cost)
-    return financial_impact, self_paid
-
-
-def _get_splitwise_impact(
-    expense: splitwise.Expense, current_user_id: int
-) -> Tuple[float, bool]:
-    """
-    Get the Financial Impact of a Splitwise Transaction
-
-    Parameters
-    ----------
-    expense: splitwise.Expense
-
-    Returns
-    -------
-    Tuple[float, bool]
-    """
-    if expense.payment is True:
-        financial_impact, self_paid = _get_payment_impact(
-            expense=expense, current_user_id=current_user_id
-        )
-    else:
-        financial_impact, self_paid = _get_expense_impact(
-            expense=expense, current_user_id=current_user_id
-        )
     return financial_impact, self_paid
 
 

--- a/lunchable/plugins/splitlunch/models.py
+++ b/lunchable/plugins/splitlunch/models.py
@@ -17,7 +17,6 @@ class SplitLunchExpense(LunchableModel):
     original_amount: float
     self_paid: bool
     financial_impact: float
-    personal_share: float
     description: str
     category: str
     details: Optional[str]

--- a/tests/plugins/splitlunch/data/splitwise_non_involved_expense.json
+++ b/tests/plugins/splitlunch/data/splitwise_non_involved_expense.json
@@ -1,0 +1,83 @@
+{
+    "id": 2166292526,
+    "group_id": 374195,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "DoorDash",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 0,
+    "payment": false,
+    "creation_method": null,
+    "transaction_method": "offline",
+    "transaction_confirmed": false,
+    "transaction_id": null,
+    "transaction_status": null,
+    "cost": "55.32",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 1234102,
+            "to": 370803,
+            "amount": "17.9"
+        }
+    ],
+    "date": "2023-02-04T21:04:21Z",
+    "created_at": "2023-02-04T21:05:40Z",
+    "created_by": {
+        "id": 370803,
+        "first_name": "XXXXXXXXXX",
+        "last_name": "XXXXXXXXXX",
+        "picture": {
+            "medium": "XXXXXXXXXX"
+        },
+        "custom_picture": true
+    },
+    "updated_at": "2023-02-04T21:05:40Z",
+    "updated_by": null,
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 13,
+        "name": "Dining out"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 1234102,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 1234102,
+            "paid_share": "0.0",
+            "owed_share": "17.9",
+            "net_balance": "-17.9"
+        },
+        {
+            "user": {
+                "id": 370803,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 370803,
+            "paid_share": "55.32",
+            "owed_share": "37.42",
+            "net_balance": "17.9"
+        }
+    ],
+    "comments": []
+}

--- a/tests/plugins/splitlunch/data/splitwise_non_involved_transfer.json
+++ b/tests/plugins/splitlunch/data/splitwise_non_involved_transfer.json
@@ -1,0 +1,83 @@
+{
+    "id": 2004096100,
+    "group_id": 374195,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "Payment",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 1,
+    "payment": true,
+    "creation_method": "payment",
+    "transaction_method": "offline",
+    "transaction_confirmed": false,
+    "transaction_id": null,
+    "transaction_status": null,
+    "cost": "716.21",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 370803,
+            "to": 1234102,
+            "amount": "716.21"
+        }
+    ],
+    "date": "2022-11-06T01:20:22Z",
+    "created_at": "2022-11-06T01:20:25Z",
+    "created_by": {
+        "id": 1234102,
+        "first_name": "XXXXXXXXXX",
+        "last_name": "XXXXXXXXXX",
+        "picture": {
+            "medium": "XXXXXXXXXX"
+        },
+        "custom_picture": false
+    },
+    "updated_at": "2022-11-06T01:20:25Z",
+    "updated_by": null,
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 18,
+        "name": "General"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 370803,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 370803,
+            "paid_share": "0.0",
+            "owed_share": "716.21",
+            "net_balance": "-716.21"
+        },
+        {
+            "user": {
+                "id": 1234102,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 1234102,
+            "paid_share": "716.21",
+            "owed_share": "0.0",
+            "net_balance": "716.21"
+        }
+    ],
+    "comments": []
+}

--- a/tests/plugins/splitlunch/data/splitwise_non_user_paid_expense.json
+++ b/tests/plugins/splitlunch/data/splitwise_non_user_paid_expense.json
@@ -1,0 +1,101 @@
+{
+    "id": 2279028334,
+    "group_id": 374195,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "Toilet paper",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 0,
+    "payment": false,
+    "creation_method": null,
+    "transaction_method": "offline",
+    "transaction_confirmed": false,
+    "transaction_id": null,
+    "transaction_status": null,
+    "cost": "29.97",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 1234059,
+            "to": 370803,
+            "amount": "9.99"
+        },
+        {
+            "from": 1234102,
+            "to": 370803,
+            "amount": "9.99"
+        }
+    ],
+    "date": "2023-04-04T23:11:38Z",
+    "created_at": "2023-04-04T23:11:51Z",
+    "created_by": {
+        "id": 370803,
+        "first_name": "XXXXXXXXXX",
+        "last_name": "XXXXXXXXXX",
+        "picture": {
+            "medium": "XXXXXXXXXX"
+        },
+        "custom_picture": true
+    },
+    "updated_at": "2023-04-04T23:11:51Z",
+    "updated_by": null,
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 14,
+        "name": "Household supplies"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 370803,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 370803,
+            "paid_share": "29.97",
+            "owed_share": "9.99",
+            "net_balance": "19.98"
+        },
+        {
+            "user": {
+                "id": 1234102,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 1234102,
+            "paid_share": "0.0",
+            "owed_share": "9.99",
+            "net_balance": "-9.99"
+        },
+        {
+            "user": {
+                "id": 1234059,
+                "first_name": "Evan",
+                "last_name": "Broder",
+                "picture": {
+                    "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+                }
+            },
+            "user_id": 1234059,
+            "paid_share": "0.0",
+            "owed_share": "9.99",
+            "net_balance": "-9.99"
+        }
+    ]
+}

--- a/tests/plugins/splitlunch/data/splitwise_non_user_paid_transfer.json
+++ b/tests/plugins/splitlunch/data/splitwise_non_user_paid_transfer.json
@@ -1,0 +1,91 @@
+{
+    "id": 2229699053,
+    "group_id": 374195,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "Payment",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 1,
+    "payment": true,
+    "creation_method": "splitwise_p2p",
+    "transaction_method": "splitwise_p2p",
+    "transaction_confirmed": true,
+    "transaction_id": "4366d04a-68cf-42f5-a6de-48d0101191f3",
+    "transaction_status": "completed",
+    "cost": "523.84",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 1234059,
+            "to": 370803,
+            "amount": "523.84"
+        }
+    ],
+    "date": "2023-03-10T17:28:50Z",
+    "created_at": "2023-03-10T17:28:50Z",
+    "created_by": {
+        "id": 370803,
+        "first_name": "XXXXXXXXXX",
+        "last_name": "XXXXXXXXXX",
+        "picture": {
+            "medium": "XXXXXXXXXX"
+        },
+        "custom_picture": true
+    },
+    "updated_at": "2023-03-15T23:13:59Z",
+    "updated_by": {
+        "id": 370803,
+        "first_name": "XXXXXXXXXX",
+        "last_name": "XXXXXXXXXX",
+        "picture": {
+            "medium": "XXXXXXXXXX"
+        },
+        "custom_picture": true
+    },
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 18,
+        "name": "General"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 370803,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 370803,
+            "paid_share": "523.84",
+            "owed_share": "0.0",
+            "net_balance": "523.84"
+        },
+        {
+            "user": {
+                "id": 1234059,
+                "first_name": "Evan",
+                "last_name": "Broder",
+                "picture": {
+                    "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+                }
+            },
+            "user_id": 1234059,
+            "paid_share": "0.0",
+            "owed_share": "523.84",
+            "net_balance": "-523.84"
+        }
+    ],
+    "comments": []
+}

--- a/tests/plugins/splitlunch/data/splitwise_user_paid_expense.json
+++ b/tests/plugins/splitlunch/data/splitwise_user_paid_expense.json
@@ -1,0 +1,102 @@
+{
+    "id": 2216325479,
+    "group_id": 374195,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "Bar",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 0,
+    "payment": false,
+    "creation_method": "equal",
+    "transaction_method": "offline",
+    "transaction_confirmed": false,
+    "transaction_id": null,
+    "transaction_status": null,
+    "cost": "92.47",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 370803,
+            "to": 1234059,
+            "amount": "30.82"
+        },
+        {
+            "from": 1234102,
+            "to": 1234059,
+            "amount": "30.83"
+        }
+    ],
+    "date": "2023-03-01T08:00:00Z",
+    "created_at": "2023-03-03T17:44:06Z",
+    "created_by": {
+        "id": 1234059,
+        "first_name": "Evan",
+        "last_name": "Broder",
+        "picture": {
+            "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+        },
+        "custom_picture": true
+    },
+    "updated_at": "2023-03-03T17:44:06Z",
+    "updated_by": null,
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 38,
+        "name": "Liquor"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 1234059,
+                "first_name": "Evan",
+                "last_name": "Broder",
+                "picture": {
+                    "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+                }
+            },
+            "user_id": 1234059,
+            "paid_share": "92.47",
+            "owed_share": "30.82",
+            "net_balance": "61.65"
+        },
+        {
+            "user": {
+                "id": 370803,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 370803,
+            "paid_share": "0.0",
+            "owed_share": "30.82",
+            "net_balance": "-30.82"
+        },
+        {
+            "user": {
+                "id": 1234102,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 1234102,
+            "paid_share": "0.0",
+            "owed_share": "30.83",
+            "net_balance": "-30.83"
+        }
+    ],
+    "comments": []
+}

--- a/tests/plugins/splitlunch/data/splitwise_user_paid_transfer.json
+++ b/tests/plugins/splitlunch/data/splitwise_user_paid_transfer.json
@@ -1,0 +1,83 @@
+{
+    "id": 1829903595,
+    "group_id": 34823819,
+    "friendship_id": null,
+    "expense_bundle_id": null,
+    "description": "Payment",
+    "repeats": false,
+    "repeat_interval": null,
+    "email_reminder": false,
+    "email_reminder_in_advance": -1,
+    "next_repeat": null,
+    "details": null,
+    "comments_count": 1,
+    "payment": true,
+    "creation_method": "payment",
+    "transaction_method": "offline",
+    "transaction_confirmed": false,
+    "transaction_id": null,
+    "transaction_status": null,
+    "cost": "431.92",
+    "currency_code": "USD",
+    "repayments": [
+        {
+            "from": 45374,
+            "to": 1234059,
+            "amount": "431.92"
+        }
+    ],
+    "date": "2022-08-02T19:37:30Z",
+    "created_at": "2022-08-02T19:37:40Z",
+    "created_by": {
+        "id": 1234059,
+        "first_name": "Evan",
+        "last_name": "Broder",
+        "picture": {
+            "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+        },
+        "custom_picture": true
+    },
+    "updated_at": "2022-08-02T19:37:40Z",
+    "updated_by": null,
+    "deleted_at": null,
+    "deleted_by": null,
+    "category": {
+        "id": 18,
+        "name": "General"
+    },
+    "receipt": {
+        "large": null,
+        "original": null
+    },
+    "users": [
+        {
+            "user": {
+                "id": 1234059,
+                "first_name": "Evan",
+                "last_name": "Broder",
+                "picture": {
+                    "medium": "https://splitwise.s3.amazonaws.com/uploads/user/avatar/1234059/medium_headshot.jpg"
+                }
+            },
+            "user_id": 1234059,
+            "paid_share": "431.92",
+            "owed_share": "0.0",
+            "net_balance": "431.92"
+        },
+        {
+            "user": {
+                "id": 45374,
+                "first_name": "XXXXXXXXXX",
+                "last_name": "XXXXXXXXXX",
+                "picture": {
+                    "medium": "XXXXXXXXXX"
+                }
+            },
+            "user_id": 45374,
+            "paid_share": "0.0",
+            "owed_share": "431.92",
+            "net_balance": "-431.92"
+        }
+    ],
+    "comments": []
+}

--- a/tests/plugins/splitlunch/test_splitwise.py
+++ b/tests/plugins/splitlunch/test_splitwise.py
@@ -40,15 +40,13 @@ def test_update_balance():
 
 def test_financial_impact():
     for [file, expected_self_paid, expected_impact] in [
-        # When someone else pays, financial impact should be negative
+        # For both expenses and transfers, when someone else pays, financial impact should be
+        # negative
         ["splitwise_non_user_paid_expense.json", False, -9.99],
+        ["splitwise_non_user_paid_transfer.json", False, -523.84],
         # When you pay, financial impact should be positive
         ["splitwise_user_paid_expense.json", True, 61.65],
-        # When someone else transfers money to you, sign should be the opposite of someone else
-        # paying for an expense
-        ["splitwise_non_user_paid_transfer.json", False, 523.84],
-        # Same for when you transfer money to someone else
-        ["splitwise_user_paid_transfer.json", True, -431.92],
+        ["splitwise_user_paid_transfer.json", True, 431.92],
         # And any transaction that doesn't involve you should have no impact
         ["splitwise_non_involved_expense.json", False, 0],
         ["splitwise_non_involved_transfer.json", False, 0],

--- a/tests/plugins/splitlunch/test_splitwise.py
+++ b/tests/plugins/splitlunch/test_splitwise.py
@@ -41,12 +41,12 @@ def test_update_balance():
 def test_financial_impact():
     for [file, expected_self_paid, expected_impact] in [
         # For both expenses and transfers, when someone else pays, financial impact should be
-        # negative
-        ["splitwise_non_user_paid_expense.json", False, -9.99],
-        ["splitwise_non_user_paid_transfer.json", False, -523.84],
-        # When you pay, financial impact should be positive
-        ["splitwise_user_paid_expense.json", True, 61.65],
-        ["splitwise_user_paid_transfer.json", True, 431.92],
+        # positive
+        ["splitwise_non_user_paid_expense.json", False, 9.99],
+        ["splitwise_non_user_paid_transfer.json", False, 523.84],
+        # When you pay, financial impact should be negative
+        ["splitwise_user_paid_expense.json", True, -61.65],
+        ["splitwise_user_paid_transfer.json", True, -431.92],
         # And any transaction that doesn't involve you should have no impact
         ["splitwise_non_involved_expense.json", False, 0],
         ["splitwise_non_involved_transfer.json", False, 0],

--- a/tests/plugins/splitlunch/test_splitwise.py
+++ b/tests/plugins/splitlunch/test_splitwise.py
@@ -39,6 +39,9 @@ def test_update_balance():
 
 
 def test_financial_impact():
+    """
+    Test the financial impact algorithm
+    """
     for [file, expected_self_paid, expected_impact] in [
         # For both expenses and transfers, when someone else pays, financial impact should be
         # positive


### PR DESCRIPTION
# Description

This introduces two new flags to `splitlunch refresh` - `--allow-self-paid` and `--allow-payments`, which override the historical behavior of filtering out those classes of transactions.

In order for this logic to behave correctly, I had to somewhat rework how splitlunch calculates the financial impact of a transaction. To convince myself I wasn't making things worse, I attempted to make it easier to test the logic around that calculation and added some tests using transactions from my Splitwise history (though I scrubbed the personal details of the other individuals involved).

For review purposes, I did my best to separate the refactoring into distinct steps which hopefully each make sense on their own; as such, I think this PR may be easiest to review commit-by-commit. (The commit messages additionally include some explanation of why I think each change represents an improvement)

As a final note, this change does lightly conflict with #71 - they both introduce flags to the `refresh_splitwise_transactions` function and make nearby edits. The conflicts should be fairly straightforward to resolve, but I'm happy to do whatever makes this easiest to manage. (I considered adjusting #71 to include these changes, but felt that it was better to leave that change simple and easy to review, given the meatiness of this change)

# Has This Been Tested?

In addition to the new automated testing around the calculations to financial impact, I've been testing with `poetry run lunchable plugins splitlunch refresh --dated-after 2023-01-01 --allow-self-paid --allow-payments`, using a local branch which contains both this change and #71. My Splitwise history includes several classes of transactions which were previously handled incorrectly, and I've verified that they are now being created with the right data.

# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/lunchable/contributing) of this project
- [x] I've installed and used `.pre_commit` on all my code
- [x] I have documented my code, particularly in hard-to-understand areas
- [x] I have made any necessary corresponding changes to the documentation
