### PR TITLE
Make mask optional for PlaidAccountObject

### DIFF
--- a/lunchable/models/plaid_accounts.py
+++ b/lunchable/models/plaid_accounts.py
@@ -83,7 +83,7 @@ class PlaidAccountObject(LunchableModel):
     name: str = Field(description=_name_description)
     type: str = Field(description=_type_description)
     subtype: str = Field(description=_subtype_description)
-    mask: str = Field(description=_mask_description)
+    mask: Optional[str] = Field(description=_mask_description)
     institution_name: str = Field(description=_institution_name_description)
     status: str = Field(description=_status_description)
     last_import: Optional[datetime.datetime] = Field(


### PR DESCRIPTION
# Description

Some of my Plaid accounts apparently don't have a mask value and it was causing validation errors when get_plaid_accounts() ran, preventing the use of that endpoint. 


# Has This Been Tested?

get_plaid_accounts() ran fine after the change. 


# Checklist:

- [x] I've read the [contributing guidelines](https://juftin.com/lunchable/contributing) of this project
- [ ] I've installed and used `.pre_commit` on all my code
- [ ] I have documented my code, particularly in hard-to-understand areas
- [ ] I have made any necessary corresponding changes to the documentation

The PR just modifies one line and it appears to be self-documenting. 
