### PR TITLE
🐛 split amount must be positive

### DIFF
--- a/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
+++ b/lunchable/plugins/splitlunch/lunchmoney_splitwise.py
@@ -878,7 +878,7 @@ class SplitLunch(splitwise.Splitwise):
                 ),
             )
             reimbursement_object = split_object.copy()
-            reimbursement_object.amount = new_transaction.financial_impact
+            reimbursement_object.amount = abs(new_transaction.financial_impact)
             reimbursement_object.category_id = self.reimbursement_category.id
             logger.debug(
                 f"Transaction split by Splitwise: {transaction.amount} -> "


### PR DESCRIPTION
# Description

- Prior to this fix, running `lunchable plugins splitlunch splitlunch-import --tag-transactions --financial-partner-id 123 --financial-partner-group-id 456` failed with:
```
LunchMoneyHTTPError: ['Sums of split transaction do not add up to the original transaction amount!']
```
- For `SplitLunchImport` tagged items, this failed to create the 2nd reimbursement split, as the `financial_impact` (and thus split amount) was negative

# Has This Been Tested?

- Ran `lunchable plugins splitlunch splitlunch-import`, see Splitwise transaction created, but Lunchmoney split failed
- Add `abs`
- Re-run, see Splitwise transaction _and_ Lunchmoney split succeed

# Checklist:

- [X] I've read the [contributing guidelines](https://juftin.com/lunchable/contributing) of this project
- [X] I've installed and used `.pre_commit` on all my code
- [X] I have documented my code, particularly in hard-to-understand areas
- [ ] I have made any necessary corresponding changes to the documentation
