### PR TITLE
Fix: coerce NaN to None for optional string fields in TransactionObject

### DIFF
--- a/lunchable/models/transactions.py
+++ b/lunchable/models/transactions.py
@@ -6,6 +6,7 @@ https://lunchmoney.dev/#transactions
 
 import datetime
 import logging
+import math
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
@@ -300,6 +301,21 @@ class TransactionObject(TransactionBaseObject):
     children: Optional[List[TransactionChildObject]] = Field(
         None, description=_TransactionDescriptions.children
     )
+
+    @field_validator(
+        "category_name",
+        "recurring_payee",
+        "recurring_cadence",
+        "recurring_type",
+        "recurring_currency",
+        "recurring_description",
+        mode="before",
+    )
+    def coerce_nan_to_none(cls, v: Any) -> Optional[str]:
+        """Coerce NaN float values to None for optional string fields."""
+        if isinstance(v, float) and math.isnan(v):
+            return None
+        return v
 
     @field_validator("plaid_metadata", mode="before")
     def to_json(cls, x: Optional[str]) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Adds a `field_validator` to `TransactionObject` that coerces `NaN` float values to `None` for optional string fields (`category_name`, `recurring_payee`, `recurring_cadence`, `recurring_type`, `recurring_currency`, `recurring_description`)
- When the Lunch Money API returns `null` for these fields, they can arrive as `NaN` floats (e.g. via pandas), causing Pydantic validation to fail with `Input should be a valid string [type=string_type, input_value=nan, input_type=float]`
- Similar pattern to the fix applied in #113 for the Assets model

Fixes #146

## Test plan

- [ ] Run `lunchable plugins primelunch` against a Lunch Money account with uncategorised transactions or transactions without recurring fields
- [ ] Verify transactions are fetched and matched without `ValidationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)